### PR TITLE
Fix test, remove istanbul

### DIFF
--- a/lib/prometheus/PushgatewayClient.js
+++ b/lib/prometheus/PushgatewayClient.js
@@ -22,10 +22,10 @@ class PushgatewayClient {
         return new Promise((resolve, reject) => {
 
             request(options, (error, response, body) => {
-
+      
                 if (error) {
                   return reject(error);
-                }
+                } 
 
                 debug("request done", options.url, expectedStatusCode, response.statusCode);
 
@@ -44,7 +44,7 @@ class PushgatewayClient {
     }
 
     _stringify(record) { //throws
-
+        
         if (typeof record !== "object" || !(record instanceof Object)) {
             throw new Error("Please provide an object as a record in the etl function");
         }
@@ -78,7 +78,7 @@ class PushgatewayClient {
 
         if (type && type.indexOf("gauge") === -1 && type.indexOf("counter") === -1) {
             // Fallback to falsy which is untyped
-            type = null;
+            type = null; 
         }
 
         const _label = label ? `{label="${label}"}` : "";
@@ -90,21 +90,15 @@ class PushgatewayClient {
         return stringRecord;
     }
 
-    postRecord(record){
-
-        let options;
-
-        try {
-          options = {
+    async postRecord(record){
+        
+        const options = {
             url: this._url,
             method: "POST",
             body: this._convertRecordToBody(record) //can throw -> reject
-          };
-        } catch(err) {
-          return Promise.reject(err); //If it throws an error, it will act as reject
-        }
+        };
 
-        return this._requestPromise(options, 202);
+        return await this._requestPromise(options, 202);
     }
 }
 

--- a/lib/prometheus/PushgatewayClient.js
+++ b/lib/prometheus/PushgatewayClient.js
@@ -22,10 +22,10 @@ class PushgatewayClient {
         return new Promise((resolve, reject) => {
 
             request(options, (error, response, body) => {
-      
+
                 if (error) {
                   return reject(error);
-                } 
+                }
 
                 debug("request done", options.url, expectedStatusCode, response.statusCode);
 
@@ -44,7 +44,7 @@ class PushgatewayClient {
     }
 
     _stringify(record) { //throws
-        
+
         if (typeof record !== "object" || !(record instanceof Object)) {
             throw new Error("Please provide an object as a record in the etl function");
         }
@@ -78,7 +78,7 @@ class PushgatewayClient {
 
         if (type && type.indexOf("gauge") === -1 && type.indexOf("counter") === -1) {
             // Fallback to falsy which is untyped
-            type = null; 
+            type = null;
         }
 
         const _label = label ? `{label="${label}"}` : "";
@@ -90,15 +90,21 @@ class PushgatewayClient {
         return stringRecord;
     }
 
-    async postRecord(record){
-        
-        const options = {
+    postRecord(record){
+
+        let options;
+
+        try {
+          options = {
             url: this._url,
             method: "POST",
             body: this._convertRecordToBody(record) //can throw -> reject
-        };
+          };
+        } catch(err) {
+          return Promise.reject(err); //If it throws an error, it will act as reject
+        }
 
-        return await this._requestPromise(options, 202);
+        return this._requestPromise(options, 202);
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
     "main": "index.js",
     "scripts": {
         "start": "node example/sink.js",
-        "test": "istanbul cover _mocha -- --recursive --exit --timeout 12500 -R spec test && istanbul check-coverage --statements 80",
-        "test-ci": "istanbul cover _mocha --report lcovonly -- --timeout 12500 --exit -R spec test/int && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage",
+        "test": "_mocha --recursive --exit --timeout 12500 -R spec test/",
+        "test-ci": "_mocha --report lcovonly --recursive --timeout 12500 --exit -R spec test/ && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage",
         "dev:start": "cd local-setup && docker-compose up -d",
         "dev:stop": "cd local-setup && docker-compose down"
     },

--- a/test/int/Connector.test.js
+++ b/test/int/Connector.test.js
@@ -136,14 +136,13 @@ describe("Connector INT", function() {
         it("should be able to get the same value from prometheus", function(done) {
 
             request({
-                url: "http://localhost:9090/api/v1/query?query=c_metric",
+                url: "http://localhost:9090/api/v1/query?query=any_metric",
                 method: 'GET'
             },
             (error, response, body) => {
-               
+
                 assert.ok(body && JSON.parse(body).status ==="success");
                 const result = JSON.parse(body);
-                console.log(result.data); //TODO remove me
                 const metric_name = result.data.result[0].metric["__name__"];
                 const metric_value = result.data.result[0].value[1] * 1;
                 assert(metric_name, "any_metric");


### PR DESCRIPTION
# Description
Since istanbul is not working correctly with `async` and `await`, this is to remove it. Also, fixing the test case with wrong metric name.

# Testing instructions
1. `yarn test`
2. Please bear in mind that sometimes Prometheus might take a while before it scrapes, so please try that a couple of times if it is failing at first