### PR TITLE
Auto cleaning feature

### DIFF
--- a/example/config.js
+++ b/example/config.js
@@ -21,8 +21,13 @@ const config = {
     options: {
       job: "promclient_job",
       additionalLabels: ["method"],
-      logging: () => {}
-    },
+      logging: () => {},
+      cleaning: {
+        interval: 20, // in seconds
+        // value: 1, // maximum value that will be pruned
+        rank: 10 // not trimming the top rank metric
+      }
+    }
   },
   http: {
     port: 3149,

--- a/lib/prometheus/PromClient.js
+++ b/lib/prometheus/PromClient.js
@@ -16,6 +16,7 @@ class PromClient {
     this.register = this.properties.register || REGISTER;
     this.metrics = {};
     this.isChanged = false;
+    this.cleaningUpInterval = null;
 
     debug(this.properties);
   }
@@ -23,13 +24,13 @@ class PromClient {
   _initiateCleaning(cleaning) {
 
     if((!cleaning.rank && !cleaning.value) || !cleaning.interval) {
-      console.error("Misconfigured auto cleaning configuration, not cleaning up automatically");
+      debug("Misconfigured auto cleaning configuration, not cleaning up automatically");
       return;
     }
 
     debug(`Auto cleaning for every ${cleaning.interval} seconds`);
 
-    setInterval(() => {
+    this.cleaningUpInterval = setInterval(() => {
 
       if (!this.isChanged) {
         debug(`Not cleaning, there's no change in registry`);
@@ -234,6 +235,13 @@ class PromClient {
 
     // Initiate auto cleaning if configured
     this._initiateCleaning(this.properties.cleaning);
+  }
+
+  stop() {
+
+    if(this.cleaningUpInterval) {
+      clearInterval(this.cleaningUpInterval);
+    }
   }
 
   setRecord(record){

--- a/lib/prometheus/PromClient.js
+++ b/lib/prometheus/PromClient.js
@@ -22,7 +22,7 @@ class PromClient {
 
   _initiateCleaning(cleaning) {
 
-    if((!cleaning.rank || !cleaning.value) || !cleaning.interval) {
+    if((!cleaning.rank && !cleaning.value) || !cleaning.interval) {
       console.error("Misconfigured auto cleaning configuration, not cleaning up automatically");
       return;
     }
@@ -74,7 +74,7 @@ class PromClient {
 
     // Sort slice, map, and delete if not the same like the sorted key
     const sortedKeys = arr.sort((a, b) => b.value.value - a.value.value)
-      .slice(0, this.properties.cleaning.rank + 1)
+      .slice(0, this.properties.cleaning.rank)
       .map(x => x.key);
 
     for (const key in metric) {

--- a/lib/prometheus/PromClient.js
+++ b/lib/prometheus/PromClient.js
@@ -15,6 +15,73 @@ class PromClient {
     this.properties = properties;
     this.register = this.properties.register || REGISTER;
     this.metrics = {};
+    this.isChanged = false;
+
+    debug(this.properties);
+  }
+
+  _initiateCleaning(cleaning) {
+
+    if((!cleaning.rank || !cleaning.value) || !cleaning.interval) {
+      console.error("Misconfigured auto cleaning configuration, not cleaning up automatically");
+      return;
+    }
+
+    debug(`Auto cleaning for every ${cleaning.interval} seconds`);
+
+    setInterval(() => {
+
+      if (!this.isChanged) {
+        debug(`Not cleaning, there's no change in registry`);
+        return;
+      }
+
+      debug("Cleaning initiated...");
+
+      for(const key in this.metrics) {
+
+        const iterable = this.metrics[key]["hashMap"];
+
+        // Check filter method
+        if (cleaning.rank) {
+          this._cleanBasedOnRank(iterable);
+        }
+
+        if (cleaning.value) {
+          this._cleanBasedOnValue(iterable);
+        }
+      }
+
+      this.isChanged = false;
+    }, cleaning.interval * 1000);
+  }
+
+  _cleanBasedOnValue(metric) {
+
+    for (const key in metric) {
+      if (metric[key].value <= this.properties.cleaning.value) {
+        delete metric[key];
+      }
+    }
+  }
+
+  _cleanBasedOnRank(metric) {
+
+    const arr = [];
+    for (const key in metric) {
+      arr.push({key: key, value: metric[key]});
+    }
+
+    // Sort slice, map, and delete if not the same like the sorted key
+    const sortedKeys = arr.sort((a, b) => b.value.value - a.value.value)
+      .slice(0, this.properties.cleaning.rank + 1)
+      .map(x => x.key);
+
+    for (const key in metric) {
+      if(!sortedKeys.includes(key)) {
+        delete metric[key];
+      }
+    }
   }
 
   _newObject(record) {
@@ -52,6 +119,10 @@ class PromClient {
   }
 
   _modify(data) {
+
+    // Set this flag to true, to initiate cleaning if there's change
+    this.isChanged = true;
+
     return new Promise((resolve, reject) => {
 
       debug(data);
@@ -156,7 +227,13 @@ class PromClient {
   }
 
   start() {
-    //empty
+
+    if(!this.properties.cleaning || typeof this.properties.cleaning !== "object") {
+      return;
+    }
+
+    // Initiate auto cleaning if configured
+    this._initiateCleaning(this.properties.cleaning);
   }
 
   setRecord(record){

--- a/lib/sink/PrometheusSinkTask.js
+++ b/lib/sink/PrometheusSinkTask.js
@@ -37,7 +37,7 @@ class PrometheusSinkTask extends SinkTask {
   }
 
   stop() {
-    //empty (con is closed by connector)
+    this.client.stop();
   }
 }
 


### PR DESCRIPTION
# Description
This will add auto cleaning feature in the registry, if the metrics endpoint is growing too big, which might make the scraping from Prometheus a hard thing to do. There are two ways this feature will clean the registry, from the value specified in config or from rank. From value means it will just trim any value of labeled metrics that are below the threshold define in config. For rank, it will just preserve the arbitary number of metrics based on the amount of the value. One of the configuration is also to specify how long before it is trying to clean.

# Testing instructions
1. Check on the `config.js`, and set `config.connector.options.cleaning` object
2. Consume some message from kafka
3. Wait until the cleaning is initated